### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Vast-Player makes it easy to playback linear VAST creatives in the browser. It c
 <html>
     <head>
         <title>Vast-Player Example</title>
-        <script src="https://cdn.jsdelivr.net/vast-player/latest/vast-player.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/vast-player@latest/dist/vast-player.min.js"></script>
         <style>
             #container {
                 width: 640px; height: 385px;
@@ -75,7 +75,7 @@ Adding to Project
     ```javascript
     requirejs.config({
         paths: {
-            VASTPlayer: 'https://cdn.jsdelivr.net/vast-player/0.2/vast-player.min.js'
+            VASTPlayer: 'https://cdn.jsdelivr.net/npm/vast-player@0.2/dist/vast-player.min.js'
         }
     });
     ```
@@ -95,7 +95,7 @@ Adding to Project
 1. Add a `<script>` to the page
 
     ```html
-    <script src="https://cdn.jsdelivr.net/vast-player/0.2/vast-player.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vast-player@0.2/dist/vast-player.min.js"></script>
     ```
 
 2. Use the module

--- a/lib/VASTPlayer.js
+++ b/lib/VASTPlayer.js
@@ -218,6 +218,6 @@ VASTPlayer.prototype.pauseAd = proxy('pauseAd');
 VASTPlayer.prototype.resumeAd = proxy('resumeAd');
 
 VASTPlayer.vpaidSWFLocation = 'https://cdn.jsdelivr.net' +
-    '/vast-player/__VERSION__/vast-player--vpaid.swf';
+    '/npm/vast-player@__VERSION__/dist/vast-player--vpaid.swf';
 
 module.exports = VASTPlayer;

--- a/test/spec/vast_player.ut.js
+++ b/test/spec/vast_player.ut.js
@@ -58,8 +58,8 @@ describe('VASTPlayer(container, config)', function() {
     describe('static:', function() {
         describe('properties:', function() {
             describe('vpaidSWFLocation', function() {
-                it('should be "https://cdn.jsdelivr.net/vast-player/__VERSION__/vast-player--vpaid.swf"', function() {
-                    expect(VASTPlayer.vpaidSWFLocation).toBe('https://cdn.jsdelivr.net/vast-player/__VERSION__/vast-player--vpaid.swf');
+                it('should be "https://cdn.jsdelivr.net/npm/vast-player@__VERSION__/dist/vast-player--vpaid.swf"', function() {
+                    expect(VASTPlayer.vpaidSWFLocation).toBe('https://cdn.jsdelivr.net/npm/vast-player@__VERSION__/dist/vast-player--vpaid.swf');
                     expect('__VERSION__').toBe(require('../../package.json').version, 'browserify-versionify is not working.');
                 });
             });


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/vast-player.

Feel free to ping me if you have any questions regarding this change.