### PR TITLE
Quality-of-life improvements for attempts to autoplay

### DIFF
--- a/lib/players/HTMLVideo.js
+++ b/lib/players/HTMLVideo.js
@@ -73,7 +73,10 @@ Object.defineProperties(HTMLVideo.prototype, {
     adDuration: { get: method(function getAdDuration() { return this.video.duration; }) },
     adVolume: {
         get: method(function getAdVolume() { return this.video.volume; }),
-        set: method(function setAdVolume(volume) { this.video.volume = volume; })
+        set: method(function setAdVolume(volume) {
+            this.video.volume = volume;
+            this.video.muted = (volume === 0);
+        })
     }
 });
 

--- a/lib/players/HTMLVideo.js
+++ b/lib/players/HTMLVideo.js
@@ -157,7 +157,9 @@ HTMLVideo.prototype.startAd = method(function startAd() {
             self.emit(VPAID_EVENTS.AdStarted);
         });
 
-        return video.play();
+        const playPromise = video.play();
+        if (playPromise.catch) playPromise.catch(reject);
+        return playPromise;
     });
 }, true);
 


### PR DESCRIPTION
In response to https://developers.google.com/web/updates/2017/09/autoplay-policy-changes, some changes to HTMLVideo:

- Use the promise returned by HTMLMediaElement.play() in modern browsers to better expose success or failure when calling vastplayer.startAd()
- Set attribute "muted" on HTML5 video element when volume is set to 0, as modern browsers allow autoplay on explicitly muted videos even with low or zero Media Engagement Index - but not on videos with volume == 0.