### PR TITLE
fix: startAd promise rejection

### DIFF
--- a/lib/players/HTMLVideo.js
+++ b/lib/players/HTMLVideo.js
@@ -148,13 +148,16 @@ HTMLVideo.prototype.startAd = method(function startAd() {
         return LiePromise.reject(new Error('The ad has already been started.'));
     }
 
-    return new LiePromise(function callPlay(resolve) {
+    return new LiePromise(function callPlay(resolve, reject) {
         once(video, HTML_MEDIA_EVENTS.PLAYING, function onplaying() {
             resolve(self);
             self.emit(VPAID_EVENTS.AdStarted);
         });
 
-        return video.play();
+        return video.play().catch(function (e) {
+            self.emit(VPAID_EVENTS.AdError, e.message)
+            reject(e);
+        });
     });
 }, true);
 

--- a/lib/players/HTMLVideo.js
+++ b/lib/players/HTMLVideo.js
@@ -132,6 +132,11 @@ HTMLVideo.prototype.load = function load(mediaFiles) {
             self.stopAd();
         });
 
+        once(video, HTML_MEDIA_EVENTS.PAUSE, function onpause() {
+            self.emit(VPAID_EVENTS.AdPaused);
+            self.pauseAd();
+        });
+
         on(video, 'click', function onclick() {
             self.emit(VPAID_EVENTS.AdClickThru, null, null, true);
         });


### PR DESCRIPTION
provides a way for reacting to HTMLVideo.play() failure & overall better way to handle ios